### PR TITLE
All users able to browse existing recipes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "rails", "~> 6.0.1"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 4.0"
+gem "will_paginate"
 
 group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    will_paginate (3.2.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.2.1)
@@ -316,6 +317,7 @@ DEPENDENCIES
   webdrivers
   webmock
   webpacker (~> 4.0)
+  will_paginate
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,7 @@
 class HomeController < ApplicationController
   def index
     @user = current_user
+    @recipes = Recipe.all
   end
 
   def create

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,7 @@ class HomeController < ApplicationController
   def index
     @user = current_user
     @recipes = Recipe.all.order("created_at DESC")
+    @recipes = Recipe.paginate(page: params[:page], per_page: 10)
   end
 
   def create

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@
 class HomeController < ApplicationController
   def index
     @user = current_user
-    @recipes = Recipe.all
+    @recipes = Recipe.all.order("created_at DESC")
   end
 
   def create

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@
 class HomeController < ApplicationController
   def index
     @user = current_user
-    @recipes = Recipe.all.order("created_at DESC")
+    @recipes = Recipe.all.order(created_at: :desc)
     @recipes = Recipe.paginate(page: params[:page], per_page: 10)
   end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -32,6 +32,7 @@
     <div class = "col-lg-12 mt-5">
       <h1> Browse recipes </h1>
       <ul>
+        <%= will_paginate @recipes %>
         <% @recipes.each do |recipe| %>
           <%= recipe.id %>
           <div class = "row">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -27,3 +27,26 @@
   </div>
 </div>
 
+<div class="container">
+  <div class="row">
+    <div class = "col-lg-12 mt-5">
+      <h1> Browse recipes </h1>
+      <ul>
+        <% @recipes.each do |recipe| %>
+          <%= recipe.id %>
+          <div class = "row">
+            <div class="col-md-2">
+              <h5>User: <%= recipe.user.name %></h5>
+            </div>
+
+            <div class = "col-lg-6 well">
+              <h4><%= recipe.title %></h4>
+              <h5><%= recipe.ingredients %></h5>
+              <h5><%= recipe.instructions %><h5>
+            </div>
+          </div>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -31,23 +31,26 @@
   <div class="row">
     <div class = "col-lg-12 mt-5">
       <h1> Browse recipes </h1>
-      <ul>
+      <dl>
         <%= will_paginate @recipes %>
         <% @recipes.each do |recipe| %>
-          <%= recipe.id %>
           <div class = "row">
             <div class="col-md-2">
-              <h5>User: <%= recipe.user.name %></h5>
+              <dt>User:</dt>
+              <dd><%= recipe.user.name %></dd>
             </div>
 
             <div class = "col-lg-6 well">
-              <h4><%= recipe.title %></h4>
-              <h5><%= recipe.ingredients %></h5>
-              <h5><%= recipe.instructions %><h5>
+              <dt>Title:</dt>
+              <dd><%= recipe.title %></dd>
+              <dt>Ingredients:</dt>
+              <dd><%= recipe.ingredients %></dd>
+              <dt>Instructions:</dt>
+              <dd><%= recipe.instructions %><dd>
             </div>
           </div>
         <% end %>
-      </ul>
+      </dl>
     </div>
   </div>
 </div>

--- a/spec/system/potential_user_browses_recipes_spec.rb
+++ b/spec/system/potential_user_browses_recipes_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "A potential user browses recipes created by others" do
+  scenario "by default, when visiting the homepage" do
+    user = create(:user)
+    recipes = create_list(:recipe, 5, user: user)
+
+    visit root_path
+
+    expect(page).to have_content(recipes[0].id)
+    expect(page).to have_content(recipes[1].id)
+    expect(page).to have_content(recipes[2].id)
+    expect(page).to have_content(recipes[3].id)
+    expect(page).to have_content(recipes[4].id)
+  end
+end

--- a/spec/system/potential_user_browses_recipes_spec.rb
+++ b/spec/system/potential_user_browses_recipes_spec.rb
@@ -9,10 +9,8 @@ RSpec.feature "A potential user browses recipes created by others" do
 
     visit root_path
 
-    expect(page).to have_content(recipes[0].id)
-    expect(page).to have_content(recipes[1].id)
-    expect(page).to have_content(recipes[2].id)
-    expect(page).to have_content(recipes[3].id)
-    expect(page).to have_content(recipes[4].id)
+    recipes.each do |recipe|
+      expect(page).to have_content(recipe.title)
+    end
   end
 end


### PR DESCRIPTION
Previously, users were only able to see their own recipes when logging in and going to their 'View recipes' page. 

Now, on the homepage, they (and any other user) can see pages of all of the recipes created, ordered by the latest created.